### PR TITLE
Restore build on modern toolchains (autoconf, GCC 15, HDF5, ld)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_PREREQ(2.65)
 AC_INIT(grvy, 0.38.0, https://github.com/hpcsi/grvy)
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_HEADER(config_grvy.h)
+AC_CONFIG_HEADERS([config_grvy.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE
 
@@ -31,7 +31,7 @@ AC_SUBST(GENERIC_MICRO_VERSION)
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_FC
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_LN_S
 AC_PROG_SED
 AM_SANITY_CHECK
@@ -41,7 +41,7 @@ LT_LIB_M
 # Enable MPI utilities?
 # ---------------------
 
-AC_ARG_ENABLE(mpi, AC_HELP_STRING([--enable-mpi],[enable MPI associated utilities]))
+AC_ARG_ENABLE(mpi, AS_HELP_STRING([--enable-mpi],[enable MPI associated utilities]))
 
 HAVE_MPI=0
 
@@ -60,7 +60,7 @@ AC_SUBST(HAVE_MPI)
 
 # Enable MPI Ocore
 ENABLE_OCORE=0
-AC_ARG_ENABLE(ocore, AC_HELP_STRING([--enable-ocore],[enable MPI ocore utilities (requires MPI)]))
+AC_ARG_ENABLE(ocore, AS_HELP_STRING([--enable-ocore],[enable MPI ocore utilities (requires MPI)]))
 if test "x$enable_ocore" = "xyes"; then
    ENABLE_OCORE=1
    AC_DEFINE(ENABLE_OCORE,1,[Enable MPI OCORE options])
@@ -88,7 +88,7 @@ AX_TLS
 #-------------------------------------------------------------------
 
 BOOST_HEADER_ONLY=0
-AC_ARG_ENABLE(boost-headers-only, AC_HELP_STRING([--enable-boost-headers-only],
+AC_ARG_ENABLE(boost-headers-only, AS_HELP_STRING([--enable-boost-headers-only],
 				  [build GRVY with Boost header-only install (disables some functionality)]),
 				  [boost_header_only=yes],[boost_header_only=no])
 				  
@@ -119,7 +119,7 @@ AX_PATH_HDF5(1.8.0,no)
 #----------------------------------
 # Enable quadrature rule generation
 #----------------------------------
-AC_ARG_ENABLE(gquad, AC_HELP_STRING([--enable-gquad],[enable Gaussian quadrature rule generation]))
+AC_ARG_ENABLE(gquad, AS_HELP_STRING([--enable-gquad],[enable Gaussian quadrature rule generation]))
 
 # If the user wants the quadrature capability, then GSL is required
 # Note that boost is also required (shared_ptr), but we already check for that.
@@ -155,8 +155,9 @@ DX_PS_FEATURE(OFF)
 
 DX_INIT_DOXYGEN(GRVY, doxygen/grvy.dox, docs)
 
-AC_OUTPUT( Makefile src/Makefile examples/Makefile test/Makefile grvy.pc \
-	   grvy.spec doxygen/Makefile src/grvy.h test/F_version.F90 )
+AC_CONFIG_FILES([Makefile src/Makefile examples/Makefile test/Makefile grvy.pc \
+	   grvy.spec doxygen/Makefile src/grvy.h test/F_version.F90])
+AC_OUTPUT
 
 # Final summary
 

--- a/m4/acx_mpi.m4
+++ b/m4/acx_mpi.m4
@@ -144,12 +144,12 @@ dnl We have to use AC_TRY_COMPILE and not AC_CHECK_HEADER because the
 dnl latter uses $CPP, not $CC (which may be mpicc).
 AC_LANG_CASE([C], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <mpi.h>],[])],[AC_MSG_RESULT(yes)], [MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [C++], [if test x != x"$MPILIBS"; then
 	AC_MSG_CHECKING([for mpi.h])
-	AC_TRY_COMPILE([#include <mpi.h>],[],[AC_MSG_RESULT(yes)], [MPILIBS=""
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <mpi.h>],[])],[AC_MSG_RESULT(yes)], [MPILIBS=""
 		AC_MSG_RESULT(no)])
 fi],
 [Fortran 77], [if test x != x"$MPILIBS"; then

--- a/m4/ax_tls.m4
+++ b/m4/ax_tls.m4
@@ -1,21 +1,22 @@
 # ===========================================================================
-#             http://www.nongnu.org/autoconf-archive/ax_tls.html
+#          https://www.gnu.org/software/autoconf-archive/ax_tls.html
 # ===========================================================================
 #
 # SYNOPSIS
 #
-#   AX_TLS
+#   AX_TLS([action-if-found], [action-if-not-found])
 #
 # DESCRIPTION
 #
 #   Provides a test for the compiler support of thread local storage (TLS)
-#   extensions. Defines TLS if it is found. Currently only knows about GCC
-#   and MSVC. I think SunPro uses the same as GCC, and Borland apparently
-#   supports either.
+#   extensions. Defines TLS if it is found. Currently knows about C++11,
+#   GCC/ICC, and MSVC. I think SunPro uses the same as GCC, and Borland
+#   apparently supports either.
 #
 # LICENSE
 #
 #   Copyright (c) 2008 Alan Woodland <ajw05@aber.ac.uk>
+#   Copyright (c) 2010 Diego Elio Petteno` <flameeyes@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -28,7 +29,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -43,32 +44,28 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-AC_DEFUN([AX_TLS], [
-  AC_MSG_CHECKING(for thread local storage (TLS) class)
-  AC_CACHE_VAL(ac_cv_tls, [
-    ax_tls_keywords="__thread __declspec(thread) none"
-    for ax_tls_keyword in $ax_tls_keywords; do
-       case $ax_tls_keyword in
-          none) ac_cv_tls=none ; break ;;
-	  *)
-             AC_TRY_COMPILE(
-                [#include <stdlib.h>
-                 static void
-                 foo(void) {
-                 static ] $ax_tls_keyword [ int bar;
-                 exit(1);
-                 }],
-                 [],
-                 [ac_cv_tls=$ax_tls_keyword ; break],
-                 ac_cv_tls=none
-             )
-	  esac
-    done
-])
+#serial 15
 
-  if test "$ac_cv_tls" != "none"; then
-    dnl AC_DEFINE([TLS], [], [If the compiler supports a TLS storage class define it to that here])
-    AC_DEFINE_UNQUOTED([TLS], $ac_cv_tls, [If the compiler supports a TLS storage class define it to that here])
-  fi
-  AC_MSG_RESULT($ac_cv_tls)
+AC_DEFUN([AX_TLS], [
+  AC_MSG_CHECKING([for thread local storage (TLS) class])
+  AC_CACHE_VAL([ac_cv_tls],
+   [for ax_tls_keyword in thread_local _Thread_local __thread '__declspec(thread)' none; do
+       AS_CASE([$ax_tls_keyword],
+          [none], [ac_cv_tls=none ; break],
+          [AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+              [#include <stdlib.h>],
+              [static  $ax_tls_keyword  int bar;]
+            )],
+            [ac_cv_tls=$ax_tls_keyword ; break],
+            [ac_cv_tls=none]
+          )]
+        )
+    done ]
+  )
+  AC_MSG_RESULT([$ac_cv_tls])
+
+  AS_IF([test "$ac_cv_tls" != "none"],
+    [AC_DEFINE_UNQUOTED([TLS],[$ac_cv_tls],[If the compiler supports a TLS storage class, define it to that here])
+     m4_ifnblank([$1],[$1],[[:]])],
+    [m4_ifnblank([$2],[$2],[[:]])])
 ])

--- a/m4/coverage.m4
+++ b/m4/coverage.m4
@@ -25,7 +25,7 @@
 AC_DEFUN([AX_CODE_COVERAGE],
 [
 
-AC_ARG_ENABLE(coverage, AC_HELP_STRING([--enable-coverage],[configure code coverage analysis tools]))
+AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage],[configure code coverage analysis tools]))
 
 HAVE_GCOV_TOOLS=0
 

--- a/m4/gsl.m4
+++ b/m4/gsl.m4
@@ -62,7 +62,7 @@ AC_ARG_ENABLE(gsltest, [  --disable-gsltest       Do not try to compile and run 
       LIBS="$LIBS $GSL_LIBS"
 
       rm -f conf.gsltest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -115,7 +115,7 @@ int main (void)
      }
 }
 
-],, no_gsl=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+])],, no_gsl=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
        CFLAGS="$ac_save_CFLAGS"
        LIBS="$ac_save_LIBS"
      fi
@@ -137,9 +137,9 @@ int main (void)
           echo "*** Could not run GSL test program, checking why..."
           CFLAGS="$CFLAGS $GSL_CFLAGS"
           LIBS="$LIBS $GSL_LIBS"
-          AC_TRY_LINK([
+          AC_LINK_IFELSE([AC_LANG_PROGRAM([
 #include <stdio.h>
-],      [ return 0; ],
+],      [ return 0; ])],
         [ echo "*** The test program compiled, but did not run. This usually means"
           echo "*** that the run-time linker is not finding GSL or finding the wrong"
           echo "*** version of GSL. If it is not finding GSL, you'll need to set your"

--- a/src/gdump.cpp
+++ b/src/gdump.cpp
@@ -4,7 +4,7 @@
 // 
 // libGRVY - a utility library for scientific computing.
 //
-// Copyright (C) 2008-2013,2018-2021 The PECOS Development Team
+// Copyright (C) 2008-2013,2018-2022 The PECOS Development Team
 // Additional Copyright (C) 2018 individual authors
 //
 // This library is free software; you can redistribute it and/or

--- a/src/grvy_hdf5.cpp
+++ b/src/grvy_hdf5.cpp
@@ -799,14 +799,14 @@ void GRVY_HDF5_Class::GRVY_HDF5_ClassImp::close_open_objects()
 
   map<std::string,hid_t>::iterator it;
 
-  for ( it=groupIds.begin(); it != groupIds.end(); it++ )
+  for ( it=groupIds.begin(); it != groupIds.end(); )
     {
       grvy_printf(GRVY_DEBUG,"%s: Closing open group (%s)\n",__func__,(*it).first.c_str());
 
       if(H5Gclose((*it).second) < 0)
 	grvy_printf(GRVY_WARN,"%s: Unable to close group (%s)\n",__func__,(*it).second);
 
-      groupIds.erase(it);
+      it = groupIds.erase(it);
     }
 
   // TODO: continue to add here for any other hdf objects which get opened

--- a/src/grvy_hdf5.cpp
+++ b/src/grvy_hdf5.cpp
@@ -804,7 +804,7 @@ void GRVY_HDF5_Class::GRVY_HDF5_ClassImp::close_open_objects()
       grvy_printf(GRVY_DEBUG,"%s: Closing open group (%s)\n",__func__,(*it).first.c_str());
 
       if(H5Gclose((*it).second) < 0)
-	grvy_printf(GRVY_WARN,"%s: Unable to close group (%s)\n",__func__,(*it).second);
+	grvy_printf(GRVY_WARN,"%s: Unable to close group (%s)\n",__func__,(*it).first.c_str());
 
       it = groupIds.erase(it);
     }

--- a/src/grvy_hdf5.cpp
+++ b/src/grvy_hdf5.cpp
@@ -332,9 +332,9 @@ vector<string> GRVY_HDF5_Class::ListSubGroups(string groupname)
 
 herr_t op_callback(hid_t loc_id, const char *name, const H5L_info_t *info, void *data)
 {
-  H5O_info_t infobuf;
+  H5O_info1_t infobuf;
 
-  herr_t status = H5Oget_info_by_name(loc_id,name,&infobuf,H5P_DEFAULT);
+  herr_t status = H5Oget_info_by_name1(loc_id,name,&infobuf,H5P_DEFAULT);
   switch(infobuf.type) 
     {
     case H5O_TYPE_GROUP:

--- a/src/grvy_ramdisk.cpp
+++ b/src/grvy_ramdisk.cpp
@@ -204,7 +204,7 @@ private:
 
 } // matches namespace GRVY
 
-#ifdef HAVE_OCORE
+#ifdef ENABLE_OCORE
 
 namespace GRVY {
 

--- a/test/C_hdf_hist_timing.c
+++ b/test/C_hdf_hist_timing.c
@@ -30,6 +30,7 @@
 #include<grvy.h>
 #include<stdio.h>
 #include<stdlib.h>
+#include<unistd.h>
 
 int main(int argc, char **argv)
 {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,6 +19,15 @@ EXTRA_DIST        = init.sh finalize.sh diff_dir.sh version hostinfo \
 CLEANFILES        = .license.stamp *.gcno *.gcda .hostinfo
 TESTS             = # Append below
 TESTS_ENVIRONMENT = GRVY_INPUT_EXAMPLE_DIR=$(srcdir)
+
+# The test suite is serial by design: init.sh/finalize.sh bookend the
+# run and gdump.sh consumes the shared .test.h5 produced by gadd.sh.
+# Serialize the test runs so "make -j check" cannot race on it.  Under
+# GNU make >= 4.4, naming the parent $(TEST_SUITE_LOG) forces its
+# prerequisites (the per-test .log targets) to build serially while
+# test compilation stays parallel; older make ignores the prerequisite
+# and simply serializes the whole directory.
+.NOTPARALLEL: $(TEST_SUITE_LOG)
 check_PROGRAMS    = # Append below
 
 # C and Fortran require libgrvy.la and libgrvyf.la, respectively

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -149,6 +149,7 @@ if HDF5_ENABLED
   TESTS                                        += C_hdf_hist_timing
   check_PROGRAMS                               += C_hdf_hist_timing
   C_hdf_hist_timing_SOURCES                     = C_hdf_hist_timing.c
+  C_hdf_hist_timing_LDADD                       = $(LIBM)
 
   TESTS                                        += F_hdf_hist_timing
   check_PROGRAMS                               += F_hdf_hist_timing


### PR DESCRIPTION
This branch gets GRVY building and testing cleanly again on current toolchains, and fixes two latent bugs in the HDF5 group-tracking code that newer compilers exposed.

Changes cause`make -j check` to pass on Ubuntu 25.10 with all optional functionality enabled.

I steered Claude to make these changes.

### Build system modernization

- Modernize obsolete autoconf m4 macros (`b44ae20`) — resolves all `autoreconf` obsolescence warnings: `AC_CONFIG_HEADER`→`AC_CONFIG_HEADERS`, `AC_PROG_LIBTOOL`→`LT_INIT`, `AC_HELP_STRING`→`AS_HELP_STRING`, `AC_OUTPUT(args)`→`AC_CONFIG_FILES`+bare `AC_OUTPUT`; upgrades `ax_tls.m4` to autoconf-archive serial 15 and converts `AC_TRY_*`→`AC_*_IFELSE` in `acx_mpi.m4`/`gsl.m4`.

### Compiler / linker fixes

- Pin HDF5 to the N=1 object-info API (`20518fc`) — `H5Oget_info_by_name` now expands to the 5-arg v3 call; pin to `H5Oget_info_by_name1`/`H5O_info1_t`.
- Gate Ocore definitions on `ENABLE_OCORE` (`0cdda32`) — they were guarded by `HAVE_OCORE`, which configure never defines, so the explicit instantiations had no definitions (a hard error on newer GCC).
- Include `<unistd.h>` for `unlink()` (`7f119a2`) — GCC 15 makes implicit declarations an error.
- Link `C_hdf_hist_timing` against libm (`f705a59`) — modern `ld --as-needed` no longer lets it borrow libm transitively.

### Bug fixes in close_open_objects()

- Fix iterator invalidation (`76b1ae0`) — `map::erase(it)` followed by `it++` was UB that segfaulted whenever an HDF group was open; switch to the C++11 `it = erase(it)` idiom.
- Fix format string (`1519146`) — a `%s` was fed an `hid_t` integer; pass the group name string instead.

### Test harness

- Serialize test runs (`3716580`) — the suite is serial by design (`gdump.sh` consumes the `.test.h5` written by `gadd.sh`); mark `$(TEST_SUITE_LOG)` `.NOTPARALLEL` so `make -j check` cannot race.

### Housekeeping

- Automatically updated Copyright header (`38000ca`).